### PR TITLE
Fix issue where no profiles results in a nil pointer exception

### DIFF
--- a/gocover-cobertura.go
+++ b/gocover-cobertura.go
@@ -94,6 +94,10 @@ func convert(in io.Reader, out io.Writer, ignore *Ignore) error {
 }
 
 func getPackages(profiles []*Profile) ([]*packages.Package, error) {
+	if len(profiles) == 0 {
+		return []*packages.Package{}, nil
+	}
+
 	var pkgNames []string
 	for _, profile := range profiles {
 		pkgNames = append(pkgNames, getPackageName(profile.FileName))

--- a/gocover-cobertura_test.go
+++ b/gocover-cobertura_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -68,7 +69,7 @@ func TestConvertEmpty(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "coverage", v.XMLName.Local)
-	require.NotNil(t, v.Sources)
+	require.Nil(t, v.Sources)
 	require.Nil(t, v.Packages)
 }
 


### PR DESCRIPTION
Currently, when `gocover-cobertura` is run without any tests, it results in a panic due to a nil pointer. 

The contents of the coverprofile generated by go test is:
```
mode: count
```

The error is:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x11ec3af]

goroutine 1 [running]:
main.convert(0x129bec8, 0xc00000e010, 0x129bee8, 0xc00000e018, 0xc00006a240, 0x0, 0x21)
        /Users/skippy/go/pkg/mod/github.com/boumenot/gocover-cobertura@v1.1.0/gocover-cobertura.go:74 +0x1af
main.main()
        /Users/skippy/go/pkg/mod/github.com/boumenot/gocover-cobertura@v1.1.0/gocover-cobertura.go:55 +0x24f
```

In this PR, when there are no profiles present, the `getPackages` returns an empty array instead of an array with a single entry which contains the nil pointer and an error object.
