### PR TITLE
add -coverpkg arg to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Usage
 
 `gocover-cobertura` reads from the standard input:
 
-    $ go test -coverprofile=coverage.txt -covermode count github.com/gorilla/mux
+    $ go test -coverprofile=coverage.txt -covermode=count -coverpkg=./... ./...
     $ gocover-cobertura < coverage.txt > coverage.xml
     
 Note that you should run this from the directory which holds your `go.mod` file.


### PR DESCRIPTION
Coverage will not be reported by `go test` for any packages which contain zero test code by default, which will cause coverage reports to be artificially inflated by `gocover-cobertura`. 
Adding `-coverpkg` will override the default coverage reporting behavior for `go test`. `-coverpkg=./...` will specify that coverage must be reported for every package regardless of whether tests are present inside a package.