### PR TITLE
Include filename when dying on a NumStmt error

### DIFF
--- a/gocover-cobertura.go
+++ b/gocover-cobertura.go
@@ -52,7 +52,7 @@ func main() {
 	}
 
 	if err := convert(os.Stdin, os.Stdout, &ignore); err != nil {
-		fatal("code coverage conversion failed: %s", err)
+		fatal("code coverage conversion failed: %s\n", err)
 	}
 }
 

--- a/profile.go
+++ b/profile.go
@@ -98,7 +98,7 @@ func ParseProfiles(in io.Reader, ignore *Ignore) ([]*Profile, error) {
 				b.EndLine == last.EndLine &&
 				b.EndCol == last.EndCol {
 				if b.NumStmt != last.NumStmt {
-					return nil, fmt.Errorf("inconsistent NumStmt: changed from %d to %d", last.NumStmt, b.NumStmt)
+					return nil, fmt.Errorf("inconsistent NumStmt: changed from %d to %d in %s:%d-%d", last.NumStmt, b.NumStmt, p.FileName, b.StartLine, b.EndLine)
 				}
 				if mode == "set" {
 					p.Blocks[j-1].Count |= b.Count


### PR DESCRIPTION
I apologize, I haven't put much time into this PR. I just encountered this error, and was frustrated that it was relatively involved to find which source file was causing the problem.

```
# old error
code coverage conversion failed: inconsistent NumStmt: changed from x to y
# new error
code coverage conversion failed: inconsistent NumStmt: changed from x to y in example.com/pkg/filename.go:24-42
```