### PR TITLE
Fix panic on missing module

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -6,16 +6,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
-golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/mod v0.31.0 h1:HaW9xtz0+kOcWKwli0ZXy79Ix+UW/vOfmWI5QVd2tgI=
 golang.org/x/mod v0.31.0/go.mod h1:43JraMp9cGx1Rx3AqioxrbrhNsLl2l/iNAvuBkrezpg=
-golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
-golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
-golang.org/x/tools v0.29.0 h1:Xx0h3TtM9rzQpQuR4dKLrdglAmCEN5Oi+P74JdhdzXE=
-golang.org/x/tools v0.29.0/go.mod h1:KMQVMRsVxU6nHCFXrBPhDB8XncLNLM0lIy/F14RP588=
 golang.org/x/tools v0.40.0 h1:yLkxfA+Qnul4cs9QA3KnlFu0lVmd8JJfoq+E41uSutA=
 golang.org/x/tools v0.40.0/go.mod h1:Ik/tzLRlbscWpqqMRjyWYDisX8bG13FrdXp3o4Sr9lc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/gocover-cobertura.go
+++ b/gocover-cobertura.go
@@ -70,6 +70,9 @@ func convert(in io.Reader, out io.Writer, ignore *Ignore) error {
 	sources := make([]*Source, 0)
 	pkgMap := make(map[string]*packages.Package)
 	for _, pkg := range pkgs {
+		if pkg.Module == nil {
+			continue
+		}
 		sources = appendIfUnique(sources, pkg.Module.Dir)
 		pkgMap[pkg.ID] = pkg
 	}
@@ -146,7 +149,8 @@ func (cov *Coverage) parseProfiles(profiles []*Profile, pkgMap map[string]*packa
 
 func (cov *Coverage) parseProfile(profile *Profile, pkgPkg *packages.Package, ignore *Ignore) error {
 	if pkgPkg == nil || pkgPkg.Module == nil {
-		return fmt.Errorf("package or module info not found for %s", profile.FileName)
+		fmt.Fprintf(os.Stderr, "warning: skipping profile %s: no package/module information available\n", profile.FileName)
+		return nil
 	}
 	fileName := profile.FileName[len(pkgPkg.Module.Path)+1:]
 	absFilePath, err := findAbsFilePath(pkgPkg, profile.FileName)

--- a/gocover-cobertura_test.go
+++ b/gocover-cobertura_test.go
@@ -77,16 +77,14 @@ func TestParseProfileNilPackages(t *testing.T) {
 	v := Coverage{}
 	profile := Profile{FileName: "does-not-exist"}
 	err := v.parseProfile(&profile, nil, &Ignore{})
-	require.Error(t, err)
-	require.Contains(t, `package or module info not found for does-not-exist`, err.Error())
+	require.NoError(t, err)
 }
 
 func TestParseProfileEmptyPackages(t *testing.T) {
 	v := Coverage{}
 	profile := Profile{FileName: "does-not-exist"}
 	err := v.parseProfile(&profile, &packages.Package{}, &Ignore{})
-	require.Error(t, err)
-	require.Contains(t, `package or module info not found for does-not-exist`, err.Error())
+	require.NoError(t, err)
 }
 
 func TestParseProfileDoesNotExist(t *testing.T) {
@@ -110,8 +108,7 @@ func TestParseProfileNotReadable(t *testing.T) {
 	v := Coverage{}
 	profile := Profile{FileName: os.DevNull}
 	err := v.parseProfile(&profile, nil, &Ignore{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "package or module info not found for")
+	require.NoError(t, err)
 }
 
 func TestParseProfilePermissionDenied(t *testing.T) {


### PR DESCRIPTION
I am experiencing panics when I use this library in my private repo. While this does not fix why it's happening, I believe it's reasonable to prevent it from panicking. Hope my fix is reasonable, I am open to any feedback, cheers 🥂 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x63ad81]

goroutine 1 [running]:
main.convert({0x728d08?, 0xc00004a020?}, {0x728d28, 0xc00004a028}, 0xc000012480)
	/home/runner/go/pkg/mod/github.com/boumenot/gocover-cobertura@v1.4.0/gocover-cobertura.go:73 +0x1a1
main.main()
	/home/runner/go/pkg/mod/github.com/boumenot/gocover-cobertura@v1.4.0/gocover-cobertura.go:54 +0x274
Error: Process completed with exit code 2.
```