### PR TITLE
Add path argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ Some flags can be passed (each flag should only be used once):
   indicating that the file has been automatically generated. See
   `genCodeRe` regexp in [ignore.go](ignore.go).
 
+
+- `-path`
+
+  specifies the path to the directory for which coverage must be calculated
+
 Troubleshooting
 ---------------
 

--- a/gocover-cobertura.go
+++ b/gocover-cobertura.go
@@ -20,6 +20,7 @@ import (
 const coberturaDTDDecl = `<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">`
 
 var byFiles bool
+var path string
 
 func fatal(format string, a ...interface{}) {
 	_, _ = fmt.Fprintf(os.Stderr, format, a...)
@@ -31,6 +32,7 @@ func main() {
 
 	flag.BoolVar(&byFiles, "by-files", false, "code coverage by file, not class")
 	flag.BoolVar(&ignore.GeneratedFiles, "ignore-gen-files", false, "ignore generated files")
+	flag.StringVar(&path, "path", ".", "set directory to cover in")
 	ignoreDirsRe := flag.String("ignore-dirs", "", "ignore dirs matching this regexp")
 	ignoreFilesRe := flag.String("ignore-files", "", "ignore files matching this regexp")
 
@@ -48,6 +50,13 @@ func main() {
 		ignore.Files, err = regexp.Compile(*ignoreFilesRe)
 		if err != nil {
 			fatal("Bad -ignore-files regexp: %s\n", err)
+		}
+	}
+
+	if path != "" {
+		err := os.Chdir(path)
+		if err != nil {
+			fatal("failed to change working directory to path %s\n", path)
 		}
 	}
 


### PR DESCRIPTION
If there is a nested directory with the main module, a panic occurs when generating the coverage file. Add an argument that specifies the path to the directory for which coverage should be calculated.