### PR TITLE
fix: deduplicate lines

### DIFF
--- a/cobertura.go
+++ b/cobertura.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/xml"
+	"slices"
 )
 
 type Coverage struct {
@@ -79,18 +80,19 @@ func (lines *Lines) NumLinesWithHits() (numLinesWithHits int64) {
 	return numLinesWithHits
 }
 
-// AddOrUpdateLine adds a line if it is a different line than the last line recorded.
-// If it's the same line as the last line recorded then we update the hits down
-// if the new hits is less; otherwise just leave it as-is
-func (lines *Lines) AddOrUpdateLine(lineNumber int, hits int64) {
-	if len(*lines) > 0 {
-		lastLine := (*lines)[len(*lines)-1]
-		if lineNumber == lastLine.Number {
-			if hits < lastLine.Hits {
-				lastLine.Hits = hits
-			}
-			return
+// AddOrUpdateLine adds a line, if it does not yet exist, or updates an existing one.
+// For count or atomic modes, the new hits are added to the existing ones,
+// while for set mode, if either has hits, the result has hits.
+func (lines *Lines) AddOrUpdateLine(lineNumber int, hits int64, mode string) {
+	if index := slices.IndexFunc(*lines, func(line *Line) bool {
+		return line.Number == lineNumber
+	}); index != -1 {
+		if mode == "set" {
+			(*lines)[index].Hits |= hits
+		} else {
+			(*lines)[index].Hits += hits
 		}
+		return
 	}
 	*lines = append(*lines, &Line{Number: lineNumber, Hits: hits})
 }

--- a/gocover-cobertura.go
+++ b/gocover-cobertura.go
@@ -241,7 +241,7 @@ func (v *fileVisitor) method(n *ast.FuncDecl) *Method {
 			continue
 		}
 		for i := b.StartLine; i <= b.EndLine; i++ {
-			method.Lines.AddOrUpdateLine(i, int64(b.Count))
+			method.Lines.AddOrUpdateLine(i, int64(b.Count), v.profile.Mode)
 		}
 	}
 	return method
@@ -250,7 +250,7 @@ func (v *fileVisitor) method(n *ast.FuncDecl) *Method {
 func (v *fileVisitor) class(n *ast.FuncDecl) *Class {
 	var className string
 	if byFiles {
-		//className = filepath.Base(v.fileName)
+		// className = filepath.Base(v.fileName)
 		//
 		// NOTE(boumenot): ReportGenerator creates links that collide if names are not distinct.
 		// This could be an issue in how I am generating the report, but I have not been able

--- a/gocover-cobertura_test.go
+++ b/gocover-cobertura_test.go
@@ -197,7 +197,8 @@ func TestConvertSetMode(t *testing.T) {
 	if l = m.Lines[0]; l.Number != 4 || l.Hits != 1 {
 		t.Errorf("unmatched line: Number:%d, Hits:%d", l.Number, l.Hits)
 	}
-	if l = m.Lines[1]; l.Number != 5 || l.Hits != 0 {
+	// Line 5 is partially covered (coverage up to column 16), but Cobertura doesn't support partial hits, so it should be counted as covered.
+	if l = m.Lines[1]; l.Number != 5 || l.Hits != 1 {
 		t.Errorf("unmatched line: Number:%d, Hits:%d", l.Number, l.Hits)
 	}
 	if l = m.Lines[2]; l.Number != 6 || l.Hits != 0 {

--- a/profile.go
+++ b/profile.go
@@ -88,29 +88,6 @@ func ParseProfiles(in io.Reader, ignore *Ignore) ([]*Profile, error) {
 
 	for _, p := range files {
 		sort.Sort(blocksByStart(p.Blocks))
-		// Merge samples from the same location.
-		j := 1
-		for i := 1; i < len(p.Blocks); i++ {
-			b := p.Blocks[i]
-			last := p.Blocks[j-1]
-			if b.StartLine == last.StartLine &&
-				b.StartCol == last.StartCol &&
-				b.EndLine == last.EndLine &&
-				b.EndCol == last.EndCol {
-				if b.NumStmt != last.NumStmt {
-					return nil, fmt.Errorf("inconsistent NumStmt: changed from %d to %d in %s:%d-%d", last.NumStmt, b.NumStmt, p.FileName, b.StartLine, b.EndLine)
-				}
-				if mode == "set" {
-					p.Blocks[j-1].Count |= b.Count
-				} else {
-					p.Blocks[j-1].Count += b.Count
-				}
-				continue
-			}
-			p.Blocks[j] = b
-			j++
-		}
-		p.Blocks = p.Blocks[:j]
 	}
 
 	// Generate a sorted slice.


### PR DESCRIPTION
The old code had two locations where line deduplication was tried:
 - The first (during profile parsing) deduplicated blocks with the same start and end. This didn't deduplicate locations completely, however, because blocks can have same start, but different end.
 - The second (during line hit calculation) assumed that duplicate lines always were adjacent and pessimistically assumed that the lower coverage was correct. When faced with two blocks with the same start and different end, this ended up creating multiple entries for the same line.

This "overlapping blocks" scenario can actually happen: with -coverpkg, go test will create blocks for each executed test package.

To replace this logic, don't attempt deduplication during profile. Instead, when adding a line, search all lines for an existing one, not just the last one, and aggregate matches if one is found.